### PR TITLE
Fix gfs url format

### DIFF
--- a/lib/forecaster/configuration.rb
+++ b/lib/forecaster/configuration.rb
@@ -5,7 +5,7 @@ module Forecaster
     attr_accessor :server, :cache_dir, :curl_path, :wgrib2_path, :records
 
     def initialize
-      @server = "http://www.ftp.ncep.noaa.gov/data/nccf/com/gfs/prod"
+      @server = "https://ftp.ncep.noaa.gov/data/nccf/com/gfs/prod"
       @cache_dir = "/tmp/forecaster"
       @wgrib2_path = "wgrib2"
 

--- a/lib/forecaster/forecast.rb
+++ b/lib/forecaster/forecast.rb
@@ -61,7 +61,7 @@ module Forecaster
 
     def url
       server = Forecaster.configuration.server
-      subdir = format("gfs.%04d%02d%02d%02d", @year, @month, @day, @run_hour)
+      subdir = format("gfs.%04d%02d%02d/%02d", @year, @month, @day, @run_hour)
       format("%s/%s/%s", server, subdir, filename)
     end
 


### PR DESCRIPTION
Tests were failing because the url format was incorrect:
Original url example:
http://www.ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/gfs.2019072900/gfs.t00z.pgrb2.0p25.f003 

Fixed example:
https://ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/gfs.20190729/00/gfs.t00z.pgrb2.0p25.f003

