### PR TITLE
Add option to configure forecast frequency

### DIFF
--- a/lib/forecaster/configuration.rb
+++ b/lib/forecaster/configuration.rb
@@ -2,10 +2,13 @@
 module Forecaster
   # Configure how to fetch and read from a forecast file.
   class Configuration
-    attr_accessor :server, :cache_dir, :curl_path, :wgrib2_path, :records
+    attr_accessor :server, :frequency, :cache_dir, :curl_path, :wgrib2_path, :records
 
     def initialize
+      #@server = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod"
+      #@frequency = 1
       @server = "https://ftp.ncep.noaa.gov/data/nccf/com/gfs/prod"
+      @frequency = 3
       @cache_dir = "/tmp/forecaster"
       @wgrib2_path = "wgrib2"
 

--- a/lib/forecaster/forecast.rb
+++ b/lib/forecaster/forecast.rb
@@ -19,8 +19,10 @@ module Forecaster
 
     def self.at(time)
       # There is a forecast every 3 hours after a run for 384 hours.
+      # On NOMADS server there also an hourly forecast up to 120 hours.
       t = time.utc
-      fct = Time.utc(t.year, t.month, t.day, (t.hour / 3) * 3)
+      n = Forecaster.configuration.frequency # 1 or 3
+      fct = Time.utc(t.year, t.month, t.day, (t.hour / n) * n)
       run = Time.utc(t.year, t.month, t.day, (t.hour / 6) * 6)
       run -= 6 * 3600 if run == fct
 
@@ -29,7 +31,8 @@ module Forecaster
 
       fct_hour = (fct - run) / 3600
 
-      raise "Time too far in the future" if fct_hour > 384
+      max = n == 1 ? 120 : 384
+      raise "Time too far in the future" if fct_hour > max
 
       Forecast.new(run.year, run.month, run.day, run.hour, fct_hour)
     end

--- a/spec/forecaster_spec.rb
+++ b/spec/forecaster_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Forecaster do
     wgrib2_path = Forecaster.configuration.wgrib2_path
     out = `#{wgrib2_path} -version`
 
-    expect(out).to start_with("v0.2")
+    expect(out).to start_with("v3.1")
   end
 
   it "fetches a forecast" do


### PR DESCRIPTION
There's an hourly forecast on NOMADS server up to 120 hours in the future. We can already configure the URL so this PR add a frequency option to download a forecast every 1 hour instead of 3 hours.

Every 3 hours: https://ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/gfs.20230816/06/atmos/
Every 1 hour: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.20230816/06/atmos/

The configuration will stay at 3 by default and use the first URL to avoid breaking changes.